### PR TITLE
fix darknet segfault

### DIFF
--- a/distance_assistant/src/darknet_custom.py
+++ b/distance_assistant/src/darknet_custom.py
@@ -62,7 +62,8 @@ class DETECTION(Structure):
     _fields_ = [("bbox", BOX), ("classes", c_int), ("prob", POINTER(c_float)),
                 ("mask", POINTER(c_float)), ("objectness", c_float),
                 ("sort_class", c_int), ("uc", POINTER(c_float)),
-                ("points", c_int)]
+                ("points", c_int), ("embeddings", POINTER(c_float)),
+                ("embedding_size", c_int), ("sim", c_float), ("track_id", c_int)]
 
 
 class DETNUMPAIR(Structure):


### PR DESCRIPTION
**Issue #**[4](https://github.com/amzn/distance-assistant/issues/4) 

**Description of changes:** changed DETECTION class in darknet_custom.py to match the the new structure as per [https://github.com/AlexeyAB/darknet/blob/master/darknet.py#L56-L68](https://github.com/AlexeyAB/darknet/blob/master/darknet.py#L56-L68). Old DETECTION class was causing segfaults on `PersonDetector.detect()`, leading to the failure of `distance_assistant_node.py`.

To reproduce, make sure you clone `AlexeyAB/darknet` again as per instructions in the README and rebuild `libdarknet.so`; rebuilding the container from scratch (--no-cache) should have the same effect.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
